### PR TITLE
Add `ViewAttachmentEntity` support

### DIFF
--- a/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
+++ b/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
@@ -28,6 +28,8 @@ struct EntityContentBuilder<Entities: EntityRegistry, Components: ComponentRegis
             
             case sceneReconstructionProvider = "SceneReconstructionProvider"
             case handTrackingProvider = "HandTrackingProvider"
+            
+            case viewAttachmentEntity = "ViewAttachmentEntity"
         }
         
         init?(rawValue: RawValue) {
@@ -73,6 +75,8 @@ struct EntityContentBuilder<Entities: EntityRegistry, Components: ComponentRegis
                     entity = try SceneReconstructionEntity(from: element, in: context)
                 case .handTrackingProvider:
                     entity = HandTrackingEntity(from: element, in: context)
+                case .viewAttachmentEntity:
+                    entity = try _ViewAttachmentEntity(from: element, in: context)
                 }
             case .custom:
                 guard let customEntity = (try Self.build([element.node], with: Entities.self, in: context)).first

--- a/Sources/LiveViewNativeRealityKit/Entities/ViewAttachmentEntity.swift
+++ b/Sources/LiveViewNativeRealityKit/Entities/ViewAttachmentEntity.swift
@@ -1,0 +1,31 @@
+//
+//  ViewAttachmentEntity.swift
+//  
+//
+//  Created by Carson Katri on 7/24/24.
+//
+
+import LiveViewNative
+import LiveViewNativeCore
+import RealityKit
+import SwiftUI
+
+final class _ViewAttachmentEntity: Entity {
+    init<R: RootRegistry, E: EntityRegistry, C: ComponentRegistry>(
+        from element: ElementNode,
+        in context: EntityContentBuilder<E, C>.Context<R>
+    ) throws {
+        super.init()
+        let attachment = element.attributeValue(for: "attachment")
+        self.components.set(ViewAttachmentComponent(attachment: attachment))
+    }
+    
+    required init() {
+        super.init()
+    }
+}
+
+struct ViewAttachmentComponent: Component {
+    let attachment: String?
+    var resolvedAttachment: Entity? = nil
+}


### PR DESCRIPTION
This adds support for the `ViewAttachmentEntity`, which allows you to include SwiftUI Views in 3D space.

First, add an `<Attachment>` element with an `id` for the `attachments` template.

```html
<RealityView>
  <Attachment
    template="attachments"
    id="my-attachment"
  >
    <Text>Embedded SwiftUI Views</Text>
  </Attachment>
</RealityView>
```

Then, use the `<ViewAttachmentEntity>` element to include this attachment in 3D space. The attachment entity can be transformed, scaled, rotated, etc. the same as any other entity. The content it references is fully interactive.

```html
<RealityView>
  ...
  <ViewAttachmentEntity
    attachment="my-attachment"
    transform:translation={[0, -0.1, 0.03]}
  />
</RealityView>
```

In this example, the `palette` attachment is included in a volume with buttons to select different colors:
<img width="1000" alt="Screenshot 2024-07-24 at 4 31 32 PM" src="https://github.com/user-attachments/assets/88c449fc-90c9-4780-b591-1e699d0445c5">
