### PR TITLE
Add `offset` attribute to mesh types

### DIFF
--- a/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
+++ b/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
@@ -28,6 +28,8 @@ struct EntityContentBuilder<Entities: EntityRegistry, Components: ComponentRegis
             
             case sceneReconstructionProvider = "SceneReconstructionProvider"
             case handTrackingProvider = "HandTrackingProvider"
+            
+            case viewAttachmentEntity = "ViewAttachmentEntity"
         }
         
         init?(rawValue: RawValue) {
@@ -73,6 +75,8 @@ struct EntityContentBuilder<Entities: EntityRegistry, Components: ComponentRegis
                     entity = try SceneReconstructionEntity(from: element, in: context)
                 case .handTrackingProvider:
                     entity = HandTrackingEntity(from: element, in: context)
+                case .viewAttachmentEntity:
+                    entity = try _ViewAttachmentEntity(from: element, in: context)
                 }
             case .custom:
                 guard let customEntity = (try Self.build([element.node], with: Entities.self, in: context)).first

--- a/Sources/LiveViewNativeRealityKit/ContentBuilders/MeshResourceContentBuilder.swift
+++ b/Sources/LiveViewNativeRealityKit/ContentBuilders/MeshResourceContentBuilder.swift
@@ -61,6 +61,22 @@ struct MeshResourceContentBuilder: ContentBuilder {
             try! mesh.replace(with: contents)
         }
         
+        if let offset = try? element.attributeValue(SIMD3<Float>.self, for: "offset") {
+            var contents = mesh.contents
+            contents.models = MeshModelCollection(mesh.contents.models.map({
+                var model = $0
+                model.parts = MeshPartCollection(model.parts.map({
+                    var part = $0
+                    part.positions = MeshBuffer(part.positions.map({
+                        $0 + offset
+                    }))
+                    return part
+                }))
+                return model
+            }))
+            try! mesh.replace(with: contents)
+        }
+        
         return [mesh]
     }
     

--- a/Sources/LiveViewNativeRealityKit/Entities/ViewAttachmentEntity.swift
+++ b/Sources/LiveViewNativeRealityKit/Entities/ViewAttachmentEntity.swift
@@ -1,0 +1,31 @@
+//
+//  ViewAttachmentEntity.swift
+//  
+//
+//  Created by Carson Katri on 7/24/24.
+//
+
+import LiveViewNative
+import LiveViewNativeCore
+import RealityKit
+import SwiftUI
+
+final class _ViewAttachmentEntity: Entity {
+    init<R: RootRegistry, E: EntityRegistry, C: ComponentRegistry>(
+        from element: ElementNode,
+        in context: EntityContentBuilder<E, C>.Context<R>
+    ) throws {
+        super.init()
+        let attachment = element.attributeValue(for: "attachment")
+        self.components.set(ViewAttachmentComponent(attachment: attachment))
+    }
+    
+    required init() {
+        super.init()
+    }
+}
+
+struct ViewAttachmentComponent: Component {
+    let attachment: String?
+    var resolvedAttachment: Entity? = nil
+}


### PR DESCRIPTION
This adds the `offset` attribute for all mesh types, such as `Box`, `Plane`, `Sphere`, etc.

This will allow dynamic meshes to offset their components. We can use this to build checkerboard meshes, stacks of spheres or boxes, etc. Previously, meshes in a `Group` were always combined at the origin.