### PR TITLE
Support building for iOS 18

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "LiveViewNativeRealityKit",
+    platforms: [.visionOS(.v1), .iOS("18.0")],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Sources/LiveViewNativeRealityKit/Components/AnchoringComponent.swift
+++ b/Sources/LiveViewNativeRealityKit/Components/AnchoringComponent.swift
@@ -40,6 +40,7 @@ extension AnchoringComponent.Target: AttributeDecodable {
         guard let value = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }
         switch value {
+        #if os(visionOS)
         case "hand":
             self = .hand(
                 try element.attributeValue(Chirality.self, for: "chirality"),
@@ -47,6 +48,7 @@ extension AnchoringComponent.Target: AttributeDecodable {
             )
         case "head":
             self = .head
+        #endif
         case "image":
             self = .image(
                 group: try element.attributeValue(String.self, for: "group"),
@@ -64,6 +66,7 @@ extension AnchoringComponent.Target: AttributeDecodable {
     }
 }
 
+#if os(visionOS)
 extension AnchoringComponent.Target.Chirality: AttributeDecodable {
     public init(from attribute: Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value
@@ -99,6 +102,7 @@ extension AnchoringComponent.Target.HandLocation: AttributeDecodable {
         }
     }
 }
+#endif
 
 extension AnchoringComponent.Target.Alignment: AttributeDecodable {
     public init(from attribute: Attribute?, on element: ElementNode) throws {

--- a/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
+++ b/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
@@ -147,6 +147,12 @@ extension Entity {
             self.components.remove(InputTargetComponent.self)
         }
         
+        if element.attributeBoolean(for: "cameraTarget") {
+            self.components.set(CameraTargetComponent())
+        } else {
+            self.components.remove(CameraTargetComponent.self)
+        }
+        
         if let modelEntity = self as? ModelEntity {
             try modelEntity.applyModelEntityAttributes(from: element, in: context)
         }

--- a/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
+++ b/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
@@ -26,10 +26,12 @@ public struct EntityContentBuilder<Entities: EntityRegistry, Components: Compone
             case modelEntity = "ModelEntity"
             case anchorEntity = "AnchorEntity"
             
+            #if os(visionOS)
             case sceneReconstructionProvider = "SceneReconstructionProvider"
             case handTrackingProvider = "HandTrackingProvider"
             
             case viewAttachmentEntity = "ViewAttachmentEntity"
+            #endif
         }
         
         public init?(rawValue: RawValue) {
@@ -71,12 +73,14 @@ public struct EntityContentBuilder<Entities: EntityRegistry, Components: Compone
                     entity = try ModelEntity(from: element, in: context)
                 case .anchorEntity:
                     entity = try AnchorEntity(from: element, in: context)
+                #if os(visionOS)
                 case .sceneReconstructionProvider:
                     entity = try SceneReconstructionEntity(from: element, in: context)
                 case .handTrackingProvider:
                     entity = HandTrackingEntity(from: element, in: context)
                 case .viewAttachmentEntity:
                     entity = try _ViewAttachmentEntity(from: element, in: context)
+                #endif
                 }
             case .custom:
                 guard let customEntity = (try Self.build([element.node], with: Entities.self, in: context)).first
@@ -217,7 +221,9 @@ extension Entity {
             self.components.set(elementNodeComponent)
         }
         
+        #if os(visionOS)
         guard !(self is SceneReconstructionEntity) else { return } // scene reconstruction creates its own child meshes
+        #endif
         
         /// The list of children previously part of this element.
         ///

--- a/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
+++ b/Sources/LiveViewNativeRealityKit/ContentBuilders/EntityContentBuilder.swift
@@ -26,12 +26,10 @@ public struct EntityContentBuilder<Entities: EntityRegistry, Components: Compone
             case modelEntity = "ModelEntity"
             case anchorEntity = "AnchorEntity"
             
-            #if os(visionOS)
             case sceneReconstructionProvider = "SceneReconstructionProvider"
             case handTrackingProvider = "HandTrackingProvider"
             
             case viewAttachmentEntity = "ViewAttachmentEntity"
-            #endif
         }
         
         public init?(rawValue: RawValue) {
@@ -73,14 +71,24 @@ public struct EntityContentBuilder<Entities: EntityRegistry, Components: Compone
                     entity = try ModelEntity(from: element, in: context)
                 case .anchorEntity:
                     entity = try AnchorEntity(from: element, in: context)
-                #if os(visionOS)
                 case .sceneReconstructionProvider:
+                    #if os(visionOS)
                     entity = try SceneReconstructionEntity(from: element, in: context)
+                    #else
+                    entity = Entity()
+                    #endif
                 case .handTrackingProvider:
+                    #if os(visionOS)
                     entity = HandTrackingEntity(from: element, in: context)
+                    #else
+                    entity = Entity()
+                    #endif
                 case .viewAttachmentEntity:
+                    #if os(visionOS)
                     entity = try _ViewAttachmentEntity(from: element, in: context)
-                #endif
+                    #else
+                    entity = Entity()
+                    #endif
                 }
             case .custom:
                 guard let customEntity = (try Self.build([element.node], with: Entities.self, in: context)).first

--- a/Sources/LiveViewNativeRealityKit/Entities/ARKitSession/ARKitSession+shared.swift
+++ b/Sources/LiveViewNativeRealityKit/Entities/ARKitSession/ARKitSession+shared.swift
@@ -5,6 +5,7 @@
 //  Created by Carson.Katri on 5/30/24.
 //
 
+#if os(visionOS)
 import ARKit
 
 enum SharedARKitSessionStore {
@@ -19,3 +20,4 @@ enum SharedARKitSessionStore {
         }
     }
 }
+#endif

--- a/Sources/LiveViewNativeRealityKit/Entities/ARKitSession/HandTracking.swift
+++ b/Sources/LiveViewNativeRealityKit/Entities/ARKitSession/HandTracking.swift
@@ -5,6 +5,7 @@
 //  Created by Carson Katri on 5/23/24.
 //
 
+#if os(visionOS)
 import LiveViewNative
 import LiveViewNativeCore
 import ARKit
@@ -152,3 +153,4 @@ class HandTrackingEntity: Entity {
         session.stop()
     }
 }
+#endif

--- a/Sources/LiveViewNativeRealityKit/Entities/ARKitSession/SceneReconstruction.swift
+++ b/Sources/LiveViewNativeRealityKit/Entities/ARKitSession/SceneReconstruction.swift
@@ -5,6 +5,7 @@
 //  Created by Carson Katri on 5/23/24.
 //
 
+#if os(visionOS)
 import LiveViewNative
 import ARKit
 import RealityKit
@@ -128,3 +129,4 @@ extension GeometrySource {
         return asArray(ofType: (T, T, T).self).map { .init($0.0, $0.1, $0.2) }
     }
 }
+#endif

--- a/Sources/LiveViewNativeRealityKit/Modifiers/RealityViewCameraControlsModifier.swift
+++ b/Sources/LiveViewNativeRealityKit/Modifiers/RealityViewCameraControlsModifier.swift
@@ -1,0 +1,40 @@
+//
+//  RealityViewCameraControlsModifier.swift
+//  
+//
+//  Created by Carson.Katri on 7/25/24.
+//
+
+#if os(iOS) || os(macOS)
+import LiveViewNative
+import LiveViewNativeStylesheet
+import SwiftUI
+import RealityKit
+
+@ParseableExpression
+struct _RealityViewCameraControlsModifier: ViewModifier {
+    public static var name: String { "realityViewCameraControls" }
+    
+    let controls: CameraControls
+    
+    init(_ controls: CameraControls) {
+        self.controls = controls
+    }
+    
+    func body(content: Content) -> some View {
+        content.realityViewCameraControls(controls)
+    }
+}
+
+extension CameraControls: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember([
+            "dolly": .dolly,
+            "none": .none,
+            "orbit": .orbit,
+            "pan": .pan,
+            "tilt": .tilt,
+        ])
+    }
+}
+#endif

--- a/Sources/LiveViewNativeRealityKit/RealityView.swift
+++ b/Sources/LiveViewNativeRealityKit/RealityView.swift
@@ -331,7 +331,9 @@ struct _RealityView<Root: RootRegistry, Entities: EntityRegistry, Components: Co
                 content.remove(child)
             }
         }
+        #if os(iOS)
         content.cameraTarget = self.updateStorage.cameraTarget
+        #endif
     }
 }
 

--- a/Sources/LiveViewNativeRealityKit/Types/RealityViewCamera+AttributeDecodable.swift
+++ b/Sources/LiveViewNativeRealityKit/Types/RealityViewCamera+AttributeDecodable.swift
@@ -1,0 +1,31 @@
+//
+//  RealityViewCamera+AttributeDecodable.swift
+//  
+//
+//  Created by Carson.Katri on 7/25/24.
+//
+
+#if os(iOS) || os(macOS)
+import LiveViewNative
+import LiveViewNativeCore
+import RealityKit
+import SwiftUI
+
+extension RealityViewCamera: AttributeDecodable {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
+        guard let value = attribute?.value
+        else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        
+        switch value {
+        case "virtual":
+            self = .virtual
+        case "worldTracking":
+            self = .worldTracking
+        default:
+            throw AttributeDecodingError.badValue(Self.self)
+        }
+    }
+}
+#else
+typealias RealityViewCamera = String
+#endif

--- a/Sources/LiveViewNativeRealityKit/Types/RealityViewCamera+AttributeDecodable.swift
+++ b/Sources/LiveViewNativeRealityKit/Types/RealityViewCamera+AttributeDecodable.swift
@@ -11,21 +11,37 @@ import LiveViewNativeCore
 import RealityKit
 import SwiftUI
 
-extension RealityViewCamera: AttributeDecodable {
-    public init(from attribute: Attribute?, on element: ElementNode) throws {
+struct _RealityViewCamera: AttributeDecodable {
+    let value: RealityViewCamera
+    
+    static var virtual: Self { Self(value: .virtual) }
+    static var worldTracking: Self { Self(value: .worldTracking) }
+    
+    init(value: RealityViewCamera) {
+        self.value = value
+    }
+    
+    init(from attribute: Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }
         
         switch value {
         case "virtual":
-            self = .virtual
+            self.value = .virtual
         case "worldTracking":
-            self = .worldTracking
+            self.value = .worldTracking
         default:
             throw AttributeDecodingError.badValue(Self.self)
         }
     }
 }
 #else
-typealias RealityViewCamera = String
+import LiveViewNative
+import LiveViewNativeCore
+
+/// A stub for compatibility across platforms.
+enum _RealityViewCamera: String, AttributeDecodable {
+    case virtual
+    case worldTracking
+}
 #endif


### PR DESCRIPTION
Use the `camera` attribute on `RealityView` to switch between AR and virtual modes.

```html
<RealityView camera="worldTracking" />
<RealityView camera="virtual" />
```

The `realityViewCameraControls(_:)` modifier can be used with the `virtual` camera mode.

```html
<RealityView camera="virtual" style="realityViewCameraControls(.orbit)" />
```

Now you can drag to orbit the 3D scene around.

Use the `cameraTarget` attribute to mark an entity as the target for orbit controls.

```html
<Entity cameraTarget />
```

Now the camera will automatically reframe to fit this entity as it moves and resizes.